### PR TITLE
add conda tos accept to fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ ENV PATH=/opt/miniconda/bin:$PATH
 
 RUN conda init bash
 
+RUN conda tos accept
+
 RUN conda env create -f rapidock_env.yaml -n RAPiDock && echo "conda activate RAPiDock" >> ~/.bashrc
 
 ENV PATH=/opt/miniconda/envs/RAPiDock/bin:$PATH


### PR DESCRIPTION
Building the docker image with instructions from the repo failed with the following message for me:

```
 > [ 7/10] RUN conda env create -f rapidock_env.yaml -n RAPiDock && echo "conda activate RAPiDock" >> ~/.bashrc:
0.929
0.929 CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels. Please accept or remove them before proceeding:
0.929     • https://repo.anaconda.com/pkgs/main
0.929     • https://repo.anaconda.com/pkgs/r
0.929
0.929 To accept a channel's Terms of Service, run the following and replace `CHANNEL` with the channel name/URL:
0.929     ‣ conda tos accept --override-channels --channel CHANNEL
0.929
0.929 To remove channels with rejected Terms of Service, run the following and replace `CHANNEL` with the channel name/URL:
0.929     ‣ conda config --remove channels CHANNEL
0.929
```

Adding `conda tos accept` after line 16 in the Dockerfile fixes this issue.